### PR TITLE
Corrections to remove QtQuck.Controls and base_locations reading.

### DIFF
--- a/mobileData/data/user_locations.txt
+++ b/mobileData/data/user_locations.txt
@@ -23,4 +23,6 @@
 #
 # Use *FSL (frequent selected locations) for any location that is frequently used
 #
-Zijin, THU	Beijing	*FSL	O	12.198	40.01569N	116.33608E	33	7	Asia/Shanghai
+Paris	Ile-de-France	fr	C	2138.551	48.85341N	2.3488E	42	9	Europe/Paris
+Paris	Texas	us	N	25.171	33.66094N	95.55551W	190	5	America/Chicago
+Paris Observatory		fr	O	0	48.836439N	2.336506E	0	5	

--- a/qml/LocationCityPicker.qml
+++ b/qml/LocationCityPicker.qml
@@ -18,7 +18,7 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 2.2
+//import QtQuick.Controls 2.2
 
 StelDialog {
 	id: root
@@ -135,7 +135,9 @@ StelDialog {
         cName = cName.toLowerCase()
         for (var i = 0; i < cList.length; i++)
         {
-            if (cList[i].toLowerCase().includes(cName)) {
+            console.debug(cList[i])
+            //if (cList[i].toLowerCase().includes(cName)) {
+            if (cList[i].toLowerCase().indexOf(cName) >= 0) {
                 temp.push(cList[i])
             }
         }

--- a/qml/StarloreDialog.qml
+++ b/qml/StarloreDialog.qml
@@ -17,8 +17,9 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
  */
 
+
 import QtQuick 2.2
-import QtQuick.Controls 2.2
+//import QtQuick.Controls 2.2
 
 StelDialog {
 	id: root
@@ -37,10 +38,10 @@ StelDialog {
 			onClicked: stellarium.currentSkyCultureI18 = modelData
 		}
 		model: stellarium.getSkyCultureListI18()
-		clip: true
-        ScrollBar.vertical: ScrollBar {
+        clip: true
+        /*ScrollBar.vertical: ScrollBar {
             active: true
-        }
+        }*/
 	}
 
 	Flickable {

--- a/rpm/stellarium.spec
+++ b/rpm/stellarium.spec
@@ -18,6 +18,7 @@ BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(Qt5Positioning)
 BuildRequires:  pkgconfig(Qt5Sensors)
+BuildRequires:  qt5-qttools-linguist
 BuildRequires:  desktop-file-utils
 
 %description

--- a/src/core/StelLocationMgr.cpp
+++ b/src/core/StelLocationMgr.cpp
@@ -33,7 +33,7 @@ StelLocationMgr::StelLocationMgr()
 	// The line below allows to re-generate the location file, you still need to gunzip it manually afterward.
     // generateBinaryLocationFile("data/base_locations.txt", false, "data/base_locations.bin");
 
-#if defined(Q_OS_ANDROID) || defined(Q_OS_UBUNTU_TOUCH)
+#if defined(Q_OS_ANDROID) || defined(Q_OS_UBUNTU_TOUCH) || defined(Q_OS_SAILFISHOS)
 	// The .gz is removed in the assets to avoid double compression.
     // Modified: loadCitiesBin won't work properly, resort to loadCities (Cheng Xinlun, Feb 20, 2017)
     locations = loadCities("data/base_locations.txt", true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,7 @@
 #endif
 #endif //Q_OS_WIN
 
+
 //! @class GettextStelTranslator
 //! Provides custom i18n support.
 class CustomQTranslator : public QTranslator
@@ -140,6 +141,7 @@ int main(int argc, char **argv)
     //app.setApplicationName("stellarium");
     //app.setApplicationVersion(StelUtils::getApplicationVersion());
     //app.setOrganizationDomain("stellarium.org");
+    app.setApplicationName("stellarium");
     app.setOrganizationName(QStringLiteral("me.lduboeuf.stellarium"));
 
 	// QApplication sets current locale, but

--- a/stellarium.desktop
+++ b/stellarium.desktop
@@ -8,6 +8,6 @@ Icon=stellarium
 Exec=stellarium
 
 [X-Sailjail]
-Permissions=Location;Sensors;Interneti;UserDirs
+Permissions=Location;Sensors;Internet;UserDirs
 OrganizationName=me.lduboeuf.stellarium
 ApplicationName=stellarium

--- a/stellarium.desktop
+++ b/stellarium.desktop
@@ -8,6 +8,6 @@ Icon=stellarium
 Exec=stellarium
 
 [X-Sailjail]
-Permissions=Location;Sensors;Internet
-OrganizationName=ch.sympato
-Application=Stellarium
+Permissions=Location;Sensors;Interneti;UserDirs
+OrganizationName=me.lduboeuf.stellarium
+ApplicationName=stellarium


### PR DESCRIPTION
Corrected the base_locations.txt reading to also cover SAILFISH,
Replaced match method in QML to, well, match county/city names in LocationCityPicker
Removed unecessary QtQuick.Controls 2.2 declarations and elements.

None of these changes should have any significant effect on other dists.